### PR TITLE
Add an application cache manifest for issue #5.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+AddType text/cache-manifest .manifest

--- a/jsonlint.manifest
+++ b/jsonlint.manifest
@@ -33,7 +33,7 @@ FALLBACK:
 # connection/name resolution attempt takes to fail) as it first tries
 # to access the website directly before falling back.
 /? index.html
-/index.html? index.html
+index.html? index.html
 
 # Enable access to proxy.php, Google Analytics, and allow linking to
 # external websites. Will only work when the client is connected to

--- a/jsonlint.manifest
+++ b/jsonlint.manifest
@@ -1,0 +1,42 @@
+CACHE MANIFEST
+
+# When updating any resources, you must bump this manifest file in
+# some way. The browser will only attempt to update resources if this
+# file’s content (i.e., the bytes, HTTP headers are irrelevant in this
+# situation) actually changes. The conventional means to do this with
+# static content is to include a revision number inside of the
+# manifest as a comment:
+#
+# revision=0
+
+# Normal static resources
+index.html
+c/js/json2.js
+c/js/jquery-1.6.1.min.js
+c/js/jquery-linedtextarea/jquery-linedtextarea.js
+c/js/jquery-linedtextarea/jquery-linedtextarea.css
+c/js/jsl.parser.js
+c/js/jsl.format.js
+c/js/jsl.interactions.js
+c/css/blueprint/compressed/screen.css
+c/css/blueprint/lib/ie.css
+c/css/blueprint/plugins/css-classes/css-classes.css
+c/css/screen.css
+c/images/logo_arc90.png
+c/images/kindling.png
+c/images/loadspinner.gif
+
+FALLBACK:
+# Special, GET parameters are parsed locally anyways so allow them to
+# work. We can only catch these URIs with fallback namespaces though,
+# so the browser takes a while to load them (however long the
+# connection/name resolution attempt takes to fail) as it first tries
+# to access the website directly before falling back.
+/? index.html
+/index.html? index.html
+
+# Enable access to proxy.php, Google Analytics, and allow linking to
+# external websites. Will only work when the client is connected to
+# the Internet.
+NETWORK:
+*

--- a/web.config
+++ b/web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <remove fileExtension=".manifest"/>
+      <mimeMap fileExtension=".manifest" mimeType="text/cache-manifest"/>
+    </staticContent>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Everything necessary to run is listed as CACHE entries. Support for the
“json” GET parameter is implemented through FALLBACK entries. Of course,
proxy.php/URI validation can only work when connectivity can be
established with the server.

Tested on IISExpress (and now also on Apache 2.2, web.config/.htaccess are necessary to ensure the correct Content-Type of the jsonlint.manifest file).