### PR TITLE
Fix formatting for "[1 2]" and similar

### DIFF
--- a/c/js/jsl.format.js
+++ b/c/js/jsl.format.js
@@ -57,10 +57,18 @@ jsl.format = (function () {
                 } 
                 break; 
             case ' ':
+                if (inString) {
+                    newJson += currentChar;
+                } else if (!json.charAt(i - 1).match(/[\s:]/)) {
+                    newJson += ' ';
+                }
+                break;
             case "\n":
             case "\t":
                 if (inString) {
                     newJson += currentChar;
+                } else if (json.charAt(i + 1).match(/[^\s}\]]/)) {
+                    newJson += ' ';
                 }
                 break;
             case '"': 


### PR DESCRIPTION
When validating expressions like `[1 2]`, the result is clearly invalid.
However, the formatter outputs the following:

```
[
    12
]
```

Clicking Validate for a second time would now return this as valid.

This change attempts to preserve some of the whitespace in invalid JSON. It's
not perfect, but it avoids the scenario described above.